### PR TITLE
Use Group ID to uniquely identify rad group (instead of group name)

### DIFF
--- a/RadToolkit/RadGroupSettings.cs
+++ b/RadToolkit/RadGroupSettings.cs
@@ -37,7 +37,7 @@ namespace Skyline.DataMiner.Utils.RadToolkit
         /// <param name="groupName">The name of the RAD group.</param>
         /// <param name="options">The options for the RAD group.</param>
         /// <param name="subgroups">The list of subgroups in the RAD group.</param>
-        [Obsolete("This constructor does not set the DataMinerID. Use the other constructor instead.", false)]
+        [Obsolete("This constructor does not set the ParameterGroupID. Use the other constructor instead.", false)]
         public RadGroupInfo(int dataMinerID, string groupName, RadGroupOptions options, List<RadSubgroupInfo> subgroups)
             : base(groupName, options, subgroups)
         {

--- a/RadToolkit/RadGroupSettings.cs
+++ b/RadToolkit/RadGroupSettings.cs
@@ -4,32 +4,6 @@ using System.Collections.Generic;
 namespace Skyline.DataMiner.Utils.RadToolkit
 {
     /// <summary>
-    /// Represents information about a RAD group, including its unique identifier. See also <seealso cref="RadGroupInfo"/> and <seealso cref="RadGroupSettings"/>.
-    /// </summary>
-    public class RadGroupInfoWithID : RadGroupInfo
-    {
-        /// <summary>
-        /// The unique identifier of the parameter group.
-        /// </summary>
-        public Guid ParameterGroupID { get; set; }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="RadGroupInfoWithID"/> class with the specified DataMiner ID,
-        /// group name, parameter group ID, options, and subgroups.
-        /// </summary>
-        /// <param name="dataMinerID">The DataMiner ID where the RAD group is configured.</param>
-        /// <param name="groupName">The name of the group.</param>
-        /// <param name="parameterGroupID">The unique identifier of the parameter group.</param>
-        /// <param name="options">The options that define the behavior and configuration of the group.</param>
-        /// <param name="subgroups">The list of subgroups associated with this group.</param>
-        public RadGroupInfoWithID(int dataMinerID, string groupName, Guid parameterGroupID, RadGroupOptions options, List<RadSubgroupInfo> subgroups)
-            : base(dataMinerID, groupName, options, subgroups)
-        {
-            ParameterGroupID = parameterGroupID;
-        }
-    }
-
-    /// <summary>
     /// Represents setting for a RAD group and its subgroups, including whether the group is currently actively monitored. See also <seealso cref="RadGroupSettings"/>.
     /// </summary>
     public class RadGroupInfo : ARadGroupSettings<RadSubgroupInfo>
@@ -40,12 +14,17 @@ namespace Skyline.DataMiner.Utils.RadToolkit
         public int DataMinerID { get; set; }
 
         /// <summary>
+        /// Gets or sets the unique identifier of the RAD group.
+        /// </summary>
+        public Guid ParameterGroupID { get; set; }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="RadGroupInfo"/> class.
         /// </summary>
         /// <param name="groupName">The name of the RAD group.</param>
         /// <param name="options">The options for the RAD group.</param>
         /// <param name="subgroups">The list of subgroups in the RAD group.</param>
-        [Obsolete("This constructor does not set the DataMinerID. Use the other constructor instead.", false)]
+        [Obsolete("This constructor does not set the DataMinerID or the ParameterGroupID. Use the other constructor instead.", false)]
         public RadGroupInfo(string groupName, RadGroupOptions options, List<RadSubgroupInfo> subgroups)
             : base(groupName, options, subgroups)
         {
@@ -58,10 +37,26 @@ namespace Skyline.DataMiner.Utils.RadToolkit
         /// <param name="groupName">The name of the RAD group.</param>
         /// <param name="options">The options for the RAD group.</param>
         /// <param name="subgroups">The list of subgroups in the RAD group.</param>
+        [Obsolete("This constructor does not set the DataMinerID. Use the other constructor instead.", false)]
         public RadGroupInfo(int dataMinerID, string groupName, RadGroupOptions options, List<RadSubgroupInfo> subgroups)
             : base(groupName, options, subgroups)
         {
             DataMinerID = dataMinerID;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RadGroupInfo"/> class.
+        /// </summary>
+        /// <param name="dataMinerID">The DataMiner ID where the RAD group is configured.</param>
+        /// <param name="groupName">The name of the RAD group.</param>
+        /// <param name="parameterGroupID">The unique identifier of the RAD group.</param>
+        /// <param name="options">The options for the RAD group.</param>
+        /// <param name="subgroups">The list of subgroups in the RAD group.</param>
+        public RadGroupInfo(int dataMinerID, string groupName, Guid parameterGroupID, RadGroupOptions options, List<RadSubgroupInfo> subgroups)
+            : base(groupName, options, subgroups)
+        {
+            DataMinerID = dataMinerID;
+            ParameterGroupID = parameterGroupID;
         }
     }
 

--- a/RadToolkit/RadGroupSettings.cs
+++ b/RadToolkit/RadGroupSettings.cs
@@ -4,6 +4,32 @@ using System.Collections.Generic;
 namespace Skyline.DataMiner.Utils.RadToolkit
 {
     /// <summary>
+    /// Represents information about a RAD group, including its unique identifier. See also <seealso cref="RadGroupInfo"/> and <seealso cref="RadGroupSettings"/>.
+    /// </summary>
+    public class RadGroupInfoWithID : RadGroupInfo
+    {
+        /// <summary>
+        /// The unique identifier of the parameter group.
+        /// </summary>
+        public Guid ParameterGroupID { get; set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RadGroupInfoWithID"/> class with the specified DataMiner ID,
+        /// group name, parameter group ID, options, and subgroups.
+        /// </summary>
+        /// <param name="dataMinerID">The DataMiner ID where the RAD group is configured.</param>
+        /// <param name="groupName">The name of the group.</param>
+        /// <param name="parameterGroupID">The unique identifier of the parameter group.</param>
+        /// <param name="options">The options that define the behavior and configuration of the group.</param>
+        /// <param name="subgroups">The list of subgroups associated with this group.</param>
+        public RadGroupInfoWithID(int dataMinerID, string groupName, Guid parameterGroupID, RadGroupOptions options, List<RadSubgroupInfo> subgroups)
+            : base(dataMinerID, groupName, options, subgroups)
+        {
+            ParameterGroupID = parameterGroupID;
+        }
+    }
+
+    /// <summary>
     /// Represents setting for a RAD group and its subgroups, including whether the group is currently actively monitored. See also <seealso cref="RadGroupSettings"/>.
     /// </summary>
     public class RadGroupInfo : ARadGroupSettings<RadSubgroupInfo>

--- a/RadToolkit/RadHelper.cs
+++ b/RadToolkit/RadHelper.cs
@@ -532,7 +532,7 @@ namespace Skyline.DataMiner.Utils.RadToolkit
             if (response == null)
                 return null;
 
-            return ParseRADGroupInfo(response.DataMinerID, response.ParameterGroupInfo);
+            return ParseRADGroupInfo(response.DataMinerID, response.ParameterGroupInfo, response.ParameterGroupID);
         }
 
         /// <summary>
@@ -571,7 +571,7 @@ namespace Skyline.DataMiner.Utils.RadToolkit
         /// Only call this when <see cref="_allowSharedModelGroups"/> is true.
         /// </summary>
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private RadGroupInfo ParseRADGroupInfo(int dataMinerID, RADGroupInfo groupInfo, Guid? parameterGroupID = null)
+        private RadGroupInfo ParseRADGroupInfo(int dataMinerID, RADGroupInfo groupInfo, Guid parameterGroupID)
         {
             if (groupInfo == null)
                 return null;
@@ -587,10 +587,7 @@ namespace Skyline.DataMiner.Utils.RadToolkit
                 var subgroupParameters = subgroup.Parameters?.Where(p => p != null).Select(p => new RadParameter(p.Key, p.Label)).ToList() ?? new List<RadParameter>();
                 subgroups.Add(new RadSubgroupInfo(subgroup.Name, subgroup.ID, subgroupParameters, subgroupOptions, subgroup.IsMonitored));
             }
-            if (parameterGroupID.HasValue)
-                return new RadGroupInfoWithID(dataMinerID, groupInfo.Name, parameterGroupID.Value, options, subgroups);
-            else
-                return new RadGroupInfo(dataMinerID, groupInfo.Name, options, subgroups);
+            return new RadGroupInfo(dataMinerID, groupInfo.Name, parameterGroupID, options, subgroups);
         }
 
         /// <summary>
@@ -600,7 +597,7 @@ namespace Skyline.DataMiner.Utils.RadToolkit
         private RadGroupInfo ParseParameterGroupInfoResponse(int dataMinerID, DMSMessage response)
         {
             if (response is GetRADParameterGroupInfoResponseMessage parameterGroupInfoResponse)
-                return ParseRADGroupInfo(dataMinerID, parameterGroupInfoResponse?.ParameterGroupInfo);
+                return ParseRADGroupInfo(dataMinerID, parameterGroupInfoResponse.ParameterGroupInfo, parameterGroupInfoResponse.ParameterGroupID);
             else if (response is GetMADParameterGroupInfoResponseMessage madParameterGroupInfoResponse)
                 return ParseMADParameterGroupInfoResponse(dataMinerID, madParameterGroupInfoResponse);
             else
@@ -736,7 +733,7 @@ namespace Skyline.DataMiner.Utils.RadToolkit
                     response.GroupInfo.Parameters?.ConvertAll(p => new RadParameter(p, string.Empty)) ?? new List<RadParameter>(), 
                     new RadSubgroupOptions(), true),
             };
-            return new RadGroupInfo(dataMinerID, response.GroupInfo.Name, options, subgroups);
+            return new RadGroupInfo(dataMinerID, response.GroupInfo.Name, Guid.Empty, options, subgroups);
         }
 #pragma warning restore CS0618 // Type or member is obsolete
 

--- a/RadToolkit/RadHelper.cs
+++ b/RadToolkit/RadHelper.cs
@@ -46,6 +46,10 @@ namespace Skyline.DataMiner.Utils.RadToolkit
         /// The minimum DataMiner version that has the <see cref="GetRADSubgroupFitScoresMessage"/> message (with an IsOutlier field in the response).
         /// </summary>
         public const string FitScoreVersion = "10.6.1.0-16537";
+        /// <summary>
+        /// The minimum DataMiner version that includes the <see cref="GetRADParameterGroupInfoResponseMessage.ParameterGroupID" /> field.
+        /// </summary>
+        public const string ParameterGroupIDInInfoResponseVersion = "10.6.2.0-0";//TODO
 
         private readonly IConnection _connection;
         private readonly Logger _logger;
@@ -57,6 +61,7 @@ namespace Skyline.DataMiner.Utils.RadToolkit
         private readonly bool _trainingConfigInAddGroupMessageAvailable;
         private readonly bool _anomalyScoreCacheAvailable;
         private readonly bool _fitScoreAvailable;
+        private readonly bool _parameterGroupIDInInfoResponseAvailable;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RadHelper"/> class.
@@ -79,6 +84,7 @@ namespace Skyline.DataMiner.Utils.RadToolkit
                 _trainingConfigInAddGroupMessageAvailable = IsDmsHigherThanMinimum(dataMinerVersion, TrainingConfigInAddGroupMessageVersion);
                 _anomalyScoreCacheAvailable = IsDmsHigherThanMinimum(dataMinerVersion, AnomalyScoreCacheVersion);
                 _fitScoreAvailable = IsDmsHigherThanMinimum(dataMinerVersion, FitScoreVersion);
+                _parameterGroupIDInInfoResponseAvailable = IsDmsHigherThanMinimum(dataMinerVersion, ParameterGroupIDInInfoResponseVersion);
             }
         }
 
@@ -115,6 +121,11 @@ namespace Skyline.DataMiner.Utils.RadToolkit
         /// Gets a value indicating whether fit score information is available on the connected DataMiner version.
         /// </summary>
         public bool FitScoreAvailable => _fitScoreAvailable;
+
+        /// <summary>
+        /// Gets a value indicating whether the ParameterGroupID field is available in the GetRADParameterGroupInfoResponseMessage on the connected DataMiner version.
+        /// </summary>
+        public bool ParameterGroupIDInInfoResponseAvailable => _parameterGroupIDInInfoResponseAvailable;
 
         /// <summary>
         /// Gets the default value for the threshold above which an anomaly will be generated.
@@ -218,7 +229,7 @@ namespace Skyline.DataMiner.Utils.RadToolkit
 
         /// <summary>
         /// Fetch the group info for a specific relational anomaly group by name. Note that this only works on DataMiner versions later than <see cref="RadGroupInfoEventCacheVersion"/>, on older versions
-        /// use the version with a dataMinerID parameter.
+        /// use the version with a dataMinerID parameter. The parameter group ID will also only be available on versions later than <see cref="ParameterGroupIDInInfoResponseVersion"/>.
         /// </summary>
         /// <param name="groupName">The name of the relational anomaly group.</param>
         /// <returns>The <see cref="RadGroupInfo"/> for the group, or <c>null</c> if not found.</returns>
@@ -532,7 +543,17 @@ namespace Skyline.DataMiner.Utils.RadToolkit
             if (response == null)
                 return null;
 
-            return ParseRADGroupInfo(response.DataMinerID, response.ParameterGroupInfo, response.ParameterGroupID);
+            Guid parameterGroupID = _parameterGroupIDInInfoResponseAvailable ? GetParameterGroupID(response) : Guid.Empty;
+            return ParseRADGroupInfo(response.DataMinerID, response.ParameterGroupInfo, parameterGroupID);
+        }
+
+        /// <summary>
+        /// Only call this when <see cref="_parameterGroupIDInInfoResponseAvailable"/> is true.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private Guid GetParameterGroupID(GetRADParameterGroupInfoResponseMessage response)
+        {
+            return response.ParameterGroupID;
         }
 
         /// <summary>
@@ -597,11 +618,18 @@ namespace Skyline.DataMiner.Utils.RadToolkit
         private RadGroupInfo ParseParameterGroupInfoResponse(int dataMinerID, DMSMessage response)
         {
             if (response is GetRADParameterGroupInfoResponseMessage parameterGroupInfoResponse)
-                return ParseRADGroupInfo(dataMinerID, parameterGroupInfoResponse.ParameterGroupInfo, parameterGroupInfoResponse.ParameterGroupID);
+            {
+                Guid parameterGroupID = _parameterGroupIDInInfoResponseAvailable ? GetParameterGroupID(parameterGroupInfoResponse) : Guid.Empty;
+                return ParseRADGroupInfo(dataMinerID, parameterGroupInfoResponse.ParameterGroupInfo, parameterGroupID);
+            }
             else if (response is GetMADParameterGroupInfoResponseMessage madParameterGroupInfoResponse)
+            {
                 return ParseMADParameterGroupInfoResponse(dataMinerID, madParameterGroupInfoResponse);
+            }
             else
+            {
                 return null;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
In the RAD Manager, the historical anomalies were shown based on the group name instead of the group ID. This would lead to unwanted behavior in some cases:
1) When a group was renamed, the historical anomalies from before the rename were not shown anymore
2) When a group was removed and a new group with the same name was added, the historical anomalies of the removed group would also be shown